### PR TITLE
Fixing the env vars

### DIFF
--- a/frontends/vuejs/public/index.html
+++ b/frontends/vuejs/public/index.html
@@ -6,6 +6,12 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <title>frontend-vue</title>
+    <script id="app-config" type="application/json">
+      {
+        "backendURL": "$BACKEND",
+        "envTest": "$ENV_TEST"
+      }
+    </script>
   </head>
   <body>
     <noscript>

--- a/frontends/vuejs/public/index.html
+++ b/frontends/vuejs/public/index.html
@@ -6,10 +6,10 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <title>frontend-vue</title>
-    <script id="app-config" type="application/json">
+    <script id="app-env" type="application/json">
       {
-        "backendURL": "$BACKEND",
-        "envTest": "$ENV_TEST"
+        "VUE_APP_BACKEND": "$VUE_APP_BACKEND",
+        "VUE_APP_ENV_TEST": "$VUE_APP_ENV_TEST"
       }
     </script>
   </head>

--- a/frontends/vuejs/src/App.vue
+++ b/frontends/vuejs/src/App.vue
@@ -2,7 +2,7 @@
   <div id="app">
     <img alt="Vue logo" src="./assets/logo.png">
     <HelloWorld msg="Welcome to Your Vue.js App"/>
-    <span>$ENV_TEST</span>
+    <span>ENV_TEST value is {{ this.$appConfig.envTest }}</span>
   </div>
 </template>
 
@@ -15,7 +15,6 @@ export default {
     HelloWorld
   }
 }
-
 </script>
 
 <style>

--- a/frontends/vuejs/src/App.vue
+++ b/frontends/vuejs/src/App.vue
@@ -2,7 +2,11 @@
   <div id="app">
     <img alt="Vue logo" src="./assets/logo.png">
     <HelloWorld msg="Welcome to Your Vue.js App"/>
-    <span>ENV_TEST value is {{ this.$appConfig.envTest }}</span>
+    <p>
+      NODE_ENV is {{ $appEnv.NODE_ENV }}<br>
+      VUE_APP_BACKEND is {{ $appEnv.VUE_APP_BACKEND }}<br>
+      VUE_APP_ENV_TEST is {{ $appEnv.VUE_APP_ENV_TEST }}
+    </p>
   </div>
 </template>
 

--- a/frontends/vuejs/src/config.js
+++ b/frontends/vuejs/src/config.js
@@ -5,7 +5,7 @@ export default function getConfig(selector) {
     if (document && document.querySelector) {
         const configEl = document.querySelector(selector);
         if (configEl) {
-            config = Object.freeze(JSON.parse(configEl.innerText));
+            config = Object.freeze(JSON.parse(configEl.textContent));
         }
     }
     return config;

--- a/frontends/vuejs/src/config.js
+++ b/frontends/vuejs/src/config.js
@@ -1,0 +1,12 @@
+// Reads a JSON string from a DOM element and returns the parsed object.
+// Returns an empty object when called from non-browser environments.
+export default function getConfig(selector) {
+    let config = {};
+    if (document && document.querySelector) {
+        const configEl = document.querySelector(selector);
+        if (configEl) {
+            config = Object.freeze(JSON.parse(configEl.innerText));
+        }
+    }
+    return config;
+}

--- a/frontends/vuejs/src/main.js
+++ b/frontends/vuejs/src/main.js
@@ -1,8 +1,12 @@
 import Vue from 'vue'
 import App from './App.vue'
+import getConfig from './config.js'
 
 Vue.config.productionTip = false
 
+Vue.prototype.$appConfig = getConfig('#app-config');
+
 new Vue({
-  render: h => h(App),
-}).$mount('#app')
+  el: '#app',
+  render: h => h(App)
+})

--- a/frontends/vuejs/src/main.js
+++ b/frontends/vuejs/src/main.js
@@ -4,7 +4,17 @@ import getConfig from './config.js'
 
 Vue.config.productionTip = false
 
-Vue.prototype.$appConfig = getConfig('#app-config');
+// Set application env vars that come from process.env in development
+// and from index.html (injected by apply-env-vars.sh) in production.
+// process.env itself cannot be updated, it is a webpack/DefinePlugin constant.
+Vue.prototype.$appEnv = process.env;
+
+if (process.env.NODE_ENV === 'production') {
+  const runtimeEnv = getConfig('#app-env')
+  for (const k in runtimeEnv) {
+    Vue.prototype.$appEnv[k] = runtimeEnv[k]
+  }
+}
 
 new Vue({
   el: '#app',

--- a/frontends/vuejs/support/apply-env-vars.sh
+++ b/frontends/vuejs/support/apply-env-vars.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 substitutions=(
-	BACKEND
-	ENV_TEST
+	VUE_APP_BACKEND
+	VUE_APP_ENV_TEST
 )
 
 uriencode()

--- a/frontends/vuejs/support/apply-env-vars.sh
+++ b/frontends/vuejs/support/apply-env-vars.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 substitutions=(
+	BACKEND
 	ENV_TEST
 )
 

--- a/helm/integration/templates/frontend-vue-deployment.yaml
+++ b/helm/integration/templates/frontend-vue-deployment.yaml
@@ -32,6 +32,8 @@ spec:
           env:
             - name: BACKEND
               value: http://{{ template "integration.backend.hostname" . }}
+            - name: ENV_TEST
+              value: example env var
           ports:
             - name: http
               containerPort: 80

--- a/helm/integration/templates/frontend-vue-deployment.yaml
+++ b/helm/integration/templates/frontend-vue-deployment.yaml
@@ -30,10 +30,10 @@ spec:
           image: "{{ .Values.image.repository }}/{{.Values.frontendvue.image.name}}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-            - name: BACKEND
+            - name: VUE_APP_BACKEND
               value: http://{{ template "integration.backend.hostname" . }}
-            - name: ENV_TEST
-              value: example env var
+            - name: VUE_APP_ENV_TEST
+              value: "example env var"
           ports:
             - name: http
               containerPort: 80


### PR DESCRIPTION
Hi Olivier,

This change might need some discussion.  It's based on an assumption that the `apply-env-vars.sh` script is in the front end to provide env vars necessary at runtime e.g. to provide the URL of the back end.  Because the front end in production mode contains only the pre-built app bundle, there is no build step to inject the current env vars into the JS and therefore they have to be provided some other way.

I found that `apply-env-vars.sh` was not working because it operates on index.html. The example code has `<span>$ENV_TEST</span>` in App.vue which in turn puts `$ENV_TEST` in the JS bundle in production, it's not in index.html.

So to get it to work I have made these changes:

* Rename the env vars to `VUE_APP_FOO` so that they are also available inside the Vue app in development mode (Vue pulls them into `process.env`) as well as production mode
* Put the env vars to be substituted in index.html instead of in App.vue
* Added a new function to read the substituted values from index.html on startup
* Because `process.env` cannot be changed in code (it is read only), put the final env vars into a new application property called `$appEnv`

This does work in both development and production builds but it is complex.

I think instead of doing this Jesse is keen to change the front end Dockerfile instead.  If it contained the Vue tools and Node then we could rebuild the app at runtime before deploying it, and it would then have access to the current env vars.  The env vars once injected in the build step would then be accessible in `process.env` inside the Vue app.

I can see arguments for both ways.