### PR TITLE
Env vars loading in dev and production modes

### DIFF
--- a/frontends/vuejs/Dockerfile
+++ b/frontends/vuejs/Dockerfile
@@ -7,15 +7,11 @@ COPY . .
 FROM base as development
 CMD npm run serve
 
-FROM base as build-stage
-RUN npm run build
-
-FROM nginx:stable-alpine as production
-RUN apk -U --no-cache add bash
+FROM base as production
+RUN apk -U --no-cache add bash nginx
+RUN mkdir /run/nginx
 COPY support/nginx.conf /etc/nginx/conf.d/default.conf
-COPY support/apply-env-vars.sh /
-
-COPY --from=build-stage /app/dist /app
+#COPY support/apply-env-vars.sh /
 
 EXPOSE 80
-CMD bin/bash -c "/apply-env-vars.sh && exec nginx -g 'daemon off;'"
+CMD /bin/bash -c "npm run build && exec nginx -g 'daemon off;'"

--- a/frontends/vuejs/src/App.vue
+++ b/frontends/vuejs/src/App.vue
@@ -2,7 +2,11 @@
   <div id="app">
     <img alt="Vue logo" src="./assets/logo.png">
     <HelloWorld msg="Welcome to Your Vue.js App"/>
-    <span>$ENV_TEST</span>
+    <p>
+      NODE_ENV is {{ env.NODE_ENV }}<br>
+      VUE_APP_BACKEND is {{ env.BACKEND }}<br>
+      VUE_APP_ENV_TEST is {{ env.ENV_TEST }}
+    </p>
   </div>
 </template>
 
@@ -11,11 +15,17 @@ import HelloWorld from './components/HelloWorld.vue'
 
 export default {
   name: 'app',
+  data: () => ({
+    env: {
+      NODE_ENV: process.env.NODE_ENV,
+      BACKEND: process.env.VUE_APP_BACKEND,
+      ENV_TEST: process.env.VUE_APP_ENV_TEST
+    }
+  }),
   components: {
     HelloWorld
   }
 }
-
 </script>
 
 <style>

--- a/frontends/vuejs/src/main.js
+++ b/frontends/vuejs/src/main.js
@@ -4,5 +4,6 @@ import App from './App.vue'
 Vue.config.productionTip = false
 
 new Vue({
-  render: h => h(App),
-}).$mount('#app')
+  el: '#app',
+  render: h => h(App)
+})

--- a/frontends/vuejs/support/apply-env-vars.sh
+++ b/frontends/vuejs/support/apply-env-vars.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
+# This file is not currently used, but can be invoked at runtime to substitute
+# the string "$VARNAME" in the file /app/dist/index.html for the value of the
+# environment variable with that name. The variable name must be defined in the
+# "substitutions" whitelist below.
+
 substitutions=(
-	ENV_TEST
+	VUE_APP_BACKEND
+	VUE_APP_ENV_TEST
 )
 
 uriencode()

--- a/frontends/vuejs/support/nginx.conf
+++ b/frontends/vuejs/support/nginx.conf
@@ -2,7 +2,7 @@ server {
   listen          80;
   server_name     _;
   server_tokens   off;
-  root            /app;
+  root            /app/dist;
   gzip_static     on;
 
   location / {

--- a/helm/integration/templates/frontend-vue-deployment.yaml
+++ b/helm/integration/templates/frontend-vue-deployment.yaml
@@ -30,8 +30,10 @@ spec:
           image: "{{ .Values.image.repository }}/{{.Values.frontendvue.image.name}}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-            - name: BACKEND
+            - name: VUE_APP_BACKEND
               value: http://{{ template "integration.backend.hostname" . }}
+            - name: VUE_APP_ENV_TEST
+              value: "example env var"
           ports:
             - name: http
               containerPort: 80


### PR DESCRIPTION
This is a replacement PR for getting the env vars working in the Vue app.  The `apply-env-vars.sh` script is no longer used but I have kept it.  Instead it now uses the standard vue build to bring in the current env vars.

Key parts:
* The env vars have to be named `VUE_APP_foo`
* The frontend Dockerfile now runs `npm run build && exec nginx` on startup

The build only takes a few seconds.

A few weeks ago I was able to reference `{{ process.env.VUE_APP_BACKEND }}` directly in the Vue template but today for some reason this does not work.  As a workaround I have mapped the vars using a `data` function in App.vue to get this to work.  @lazaruslarue I wonder if you have any ideas about this.